### PR TITLE
Feat/subtitle formats drag

### DIFF
--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -381,6 +381,24 @@ class MediaCategories:
         "license",
         "readme",
     }
+    _SUBTITLE_SET: set[str] = {
+        ".ass",
+        ".dfxp",
+        ".idx",
+        ".itt",
+        ".lrc",
+        ".rt",
+        ".sami",
+        ".sbv",
+        ".scc",
+        ".smi",
+        ".srt",
+        ".ssa",
+        ".stl",
+        ".sub",
+        ".ttml",
+        ".vtt",
+    } 
     _PRESENTATION_SET: set[str] = {
         ".key",
         ".odp",
@@ -628,7 +646,7 @@ class MediaCategories:
     )
     TEXT_TYPES = MediaCategory(
         media_type=MediaType.TEXT,
-        extensions=_DOCUMENT_SET | _PLAINTEXT_SET,
+        extensions=_DOCUMENT_SET | _PLAINTEXT_SET | _SUBTITLE_SET,
         is_iana=True,
         name="text",
     )

--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -398,7 +398,7 @@ class MediaCategories:
         ".sub",
         ".ttml",
         ".vtt",
-    } 
+    }
     _PRESENTATION_SET: set[str] = {
         ".key",
         ".odp",

--- a/tests/test_media_types_subtitles.py
+++ b/tests/test_media_types_subtitles.py
@@ -2,6 +2,7 @@ import pytest
 
 from tagstudio.core.media_types import MediaCategories, MediaType
 
+
 @pytest.mark.parametrize(
     "ext",
     [
@@ -17,6 +18,5 @@ from tagstudio.core.media_types import MediaCategories, MediaType
         ".ttml",
     ],
 )
-
 def test_subtitle_extensions_are_classified_as_text(ext: str) -> None:
     assert MediaType.TEXT in MediaCategories.get_types(ext)

--- a/tests/test_media_types_subtitles.py
+++ b/tests/test_media_types_subtitles.py
@@ -1,0 +1,22 @@
+import pytest
+
+from tagstudio.core.media_types import MediaCategories, MediaType
+
+@pytest.mark.parametrize(
+    "ext",
+    [
+        ".ass",
+        ".idx",
+        ".scc",
+        ".srt",
+        ".ssa",
+        ".sub",
+        ".vtt",
+        ".sbv",
+        ".stl",
+        ".ttml",
+    ],
+)
+
+def test_subtitle_extensions_are_classified_as_text(ext: str) -> None:
+    assert MediaType.TEXT in MediaCategories.get_types(ext)


### PR DESCRIPTION
The implementation of the subtitle formats is finished.
Documentation for the related changes has been added.
Test files and documentation for the test updates are still missing (optional and to be added later).